### PR TITLE
[RunWhen] - GitOps Manifest Updates for null null

### DIFF
--- a/docs/install/k8s/00-resource-quota.yaml
+++ b/docs/install/k8s/00-resource-quota.yaml
@@ -4,7 +4,7 @@ metadata:
   name: compute-resources
 spec:
   hard:
-    requests.cpu: "50m"
+    requests.cpu: "350m"
     requests.memory: 128Mi
     limits.cpu: "2"
     limits.memory: 2Gi


### PR DESCRIPTION
### RunSession Details

A RunSession (started by shea.stewart@runwhen.com) with the following tasks has produced this Pull Request: 

- Remediate Readiness and Liveness Probe GitOps Manifests Namespace `${NAMESPACE}`, Increase ResourceQuota for Namespace `${NAMESPACE}`

To view the RunSession, click [this link](https://app.test.runwhen.com/map/t-shea-t-01#selectedRunSessions=838)

### Change Details
Increasing ResourceQuota `compute-resources` for `requests.cpu` to `350` in namespace `recipes`

The following details prompted this change: 
```
{
  "remediation_type": "resourcequota_update",
  "increase_percentage": "40",
  "limit_type": "hard",
  "current_value": "50",
  "suggested_value": "350",
  "quota_name": "compute-resources",
  "resource": "requests.cpu",
  "usage": "at or above 100%",
  "severity": "1",
  "next_step": "Increase the resource quota for requests.cpu in `recipes`"
}
```

---
[RunWhen Workspace](https://app.test.runwhen.com/map/t-shea-t-01)