### PR TITLE
[RunWhen] - GitOps Manifest Updates for ResourceQuota compute-resources

### DIFF
--- a/docs/install/k8s/00-resource-quota.yaml
+++ b/docs/install/k8s/00-resource-quota.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   hard:
     requests.cpu: "50m"
-    requests.memory: 128Mi
+    requests.memory: 179Mi
     limits.cpu: "2"
     limits.memory: 2Gi


### PR DESCRIPTION
### RunSession Details

A RunSession (started by shea.stewart@runwhen.com) with the following tasks has produced this Pull Request: 

- Remediate Readiness and Liveness Probe GitOps Manifests Namespace `${NAMESPACE}`, Increase ResourceQuota for Namespace `${NAMESPACE}`

To view the RunSession, click [this link](https://app.test.runwhen.com/map/t-shea-t-01#selectedRunSessions=843)

### Change Details
Increasing ResourceQuota `compute-resources` for `requests.memory` to `179` in namespace `recipes`

The following details prompted this change: 
```
{
  "remediation_type": "resourcequota_update",
  "increase_percentage": "40",
  "limit_type": "hard",
  "current_value": "128",
  "suggested_value": "179",
  "quota_name": "compute-resources",
  "resource": "requests.memory",
  "usage": "at or above 100%",
  "severity": "1",
  "next_step": "Increase the resource quota for requests.memory in `recipes`"
}
```

---
[RunWhen Workspace](https://app.test.runwhen.com/map/t-shea-t-01)