### PR TITLE
[RunWhen] - GitOps Manifest Updates for Deployment recipes

### DIFF
--- a/docs/install/k8s/50-deployment.yaml
+++ b/docs/install/k8s/50-deployment.yaml
@@ -94,7 +94,7 @@ spec:
               name: gunicorn
           resources:
             requests:
-              cpu: 125m
+              cpu: 20m
               memory: 64Mi
           volumeMounts:
             - mountPath: /media


### PR DESCRIPTION
### RunSession Details

A RunSession (started by none) with the following tasks has produced this Pull Request: 

- 

To view the RunSession, click [this link](none/map/none#selectedRunSessions=none)

### Change Details
Modifying resource request for container `recipes-nginx` in  `recipes` to `20` in namespace `recipes` based on VPA recommendation.

The following details prompted this change: 
```
{
  "remediation_type": "resource_request_update",
  "vpa_name": "recipes-vpa",
  "resource": "cpu",
  "current_value": "125",
  "suggested_value": "20",
  "target_kind": "Deployment",
  "target_name": "recipes",
  "container": "recipes-nginx",
  "severity": "4",
  "next_step": "Adjust pod resources to match VPA recommendation in `recipes`"
}
```

---
[RunWhen Workspace](none/map/none)