### PR TITLE
[RunWhen] - GitOps Manifest Updates for ResourceQuota-compute-resources

### DIFF
--- a/docs/install/k8s/00-resource-quota.yaml
+++ b/docs/install/k8s/00-resource-quota.yaml
@@ -4,7 +4,7 @@ metadata:
   name: compute-resources
 spec:
   hard:
-    requests.cpu: "375m"
-    requests.memory: 384Mi
+    requests.cpu: "525m"
+    requests.memory: 537Mi
     limits.cpu: "2"
     limits.memory: 2Gi


### PR DESCRIPTION
### RunSession Details

A RunSession (started by t-sandbox-sa@workspaces.runwhen.com) with the following tasks has produced this Pull Request: 

- Increase ResourceQuota for Namespace `${NAMESPACE}`

To view the RunSession, click [this link](https://app.test.runwhen.com/map/t-sandbox#selectedRunSessions=1065)

### Change Details
[Change] Increasing ResourceQuota `compute-resources` for `requests.cpu` to `525` in namespace `recipes`.<br>[Change] Increasing ResourceQuota `compute-resources` for `requests.memory` to `537` in namespace `recipes`.<br>

The following details prompted this change: 
```
{
  "object_type": "ResourceQuota",
  "object_name": "compute-resources",
  "remediation_type": "resourcequota_update",
  "increase_percentage": "40",
  "limit_type": "hard",
  "current_value": "375",
  "suggested_value": "525",
  "quota_name": "compute-resources",
  "resource": "requests.cpu",
  "usage": "at or above 100%",
  "severity": "1",
  "next_step": "Increase the resource quota for requests.cpu in `recipes`"
}{
  "object_type": "ResourceQuota",
  "object_name": "compute-resources",
  "remediation_type": "resourcequota_update",
  "increase_percentage": "40",
  "limit_type": "hard",
  "current_value": "384",
  "suggested_value": "537",
  "quota_name": "compute-resources",
  "resource": "requests.memory",
  "usage": "at or above 100%",
  "severity": "1",
  "next_step": "Increase the resource quota for requests.memory in `recipes`"
}
```

---
[RunWhen Workspace](https://app.test.runwhen.com/map/t-sandbox)